### PR TITLE
allow user to set a Timeout for REST calls to schemaregistry.

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type KafkaConfig struct {
@@ -52,11 +53,12 @@ type ConnectConfig struct {
 	SkipVerify bool   `yaml:"skipVerify"`
 }
 type SRConfig struct {
-	Url        string `yaml:"url"`
-	Username   string `yaml:"username"`
-	Password   string `yaml:"password"`
-	CAPath     string `yaml:"caPath"` // Add a trusted CA
-	SkipVerify bool   `yaml:"skipVerify"`
+	Url        string        `yaml:"url"`
+	Timeout    time.Duration `yaml:"timeout"` // Allow setting custom timeout for API calls
+	Username   string        `yaml:"username"`
+	Password   string        `yaml:"password"`
+	CAPath     string        `yaml:"caPath"` // Add a trusted CA
+	SkipVerify bool          `yaml:"skipVerify"`
 }
 type Configuration struct {
 	Connections struct {

--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -41,6 +41,9 @@ Config yaml structure:
      schemaregistry:
        # The URL of the schema registry
        url: "http://localhost:8081"
+       # Timeout for REST calls made to schema registry in seconds
+       # Defaults to 5. If you have many subjects you may want to increase this
+       timeout: 10
        # Username to use to authenticate
        username: "username"
        # Password to use to authenticate

--- a/schemas.go
+++ b/schemas.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"time"
 )
 
 // Schema object to keep track of desired/requested state
@@ -88,11 +89,17 @@ type SRAdmin struct {
 
 // Create a new SRAdmin
 func NewSRAdmin(config *SRConfig) SRAdmin {
+	var timeout time.Duration = 5
 	srclient := srclient.CreateSchemaRegistryClient(config.Url)
+	// Set a default for Timeouts or use config provided one
+	if config.Timeout != 0 {
+		timeout = config.Timeout
+	}
+	srclient.SetTimeout(timeout * time.Second)
+
 	if config.Username != "" && config.Password != "" {
 		srclient.SetCredentials(config.Username, config.Password)
 	}
-
 	sradmin := SRAdmin{Client: *srclient, user: config.Username, pass: config.Password}
 	sradmin.url = config.Url
 	if config.CAPath != "" {


### PR DESCRIPTION
Allow setting a timeout, in seconds for REST calls made to the schema registry.

In the config YAML a new `timeout` key has been added that will default to 5s i omitted.
Docs updated accordingly