### PR TITLE
Fix/consumer nullvalue

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -209,9 +209,14 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 			key = string(message.Key)
 		}
 		if c.deserializeValue {
-			val, valSchemaID, err = c.DeserializePayload(message.Value)
-			if err != nil {
-				log.Fatal(err)
+			if message.Value == nil {
+				val = "Gafkalo: NULL (TOMBSTONE?)!"
+			} else {
+
+				val, valSchemaID, err = c.DeserializePayload(message.Value)
+				if err != nil {
+					log.Fatal(err)
+				}
 			}
 
 		} else {

--- a/consumer.go
+++ b/consumer.go
@@ -210,7 +210,7 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 		}
 		if c.deserializeValue {
 			if message.Value == nil {
-				val = "Gafkalo: NULL (TOMBSTONE?)!"
+				val = "Null (Tombstone?)"
 			} else {
 
 				val, valSchemaID, err = c.DeserializePayload(message.Value)

--- a/consumer.go
+++ b/consumer.go
@@ -182,7 +182,7 @@ func (c *Consumer) DeserializePayload(payload []byte) (string, int, error) {
 		return resp, 0, errors.New("payload <5 bytes. Not schema registry wire format")
 	}
 	schemaID := binary.BigEndian.Uint32(payload[1:5])
-	// TODO Cache the Schema internally
+	// No need to cache the schema ourselves , as the srclient will do caching internally
 	schema, err := c.SRClient.GetSchema(int(schemaID))
 	if err != nil {
 		return resp, 0, fmt.Errorf("failed to deserialize schema ID [%d] with error: %s", schemaID, err)


### PR DESCRIPTION
Don't try to deserialize Null values as that crashes Gafkalo. Instead display a nice message that this is Null and possibly a tombstone.
Fix #21 
