### PR TITLE
Add support for Custom rolebnding definitions

### DIFF
--- a/data/sample.yaml
+++ b/data/sample.yaml
@@ -85,6 +85,36 @@ clients:
         # if not specified, roles is [DeveloperRead]
         roles: ["ResourceOwner"]
         isLiteral: true
+    # IT is also possible to set rolebindings directly, instead of the "convenience" settings . 
+    # the format is as follows:
+    rolebindings:
+      # context can be one of:
+      # KAFKA | SR | KSQLDB | CONNECT 
+      - context: KAFKA 
+        # Scope can be one of CLUSTER | RESOURCE
+        scope: RESOURCE
+        # Role , for CLUSTER or RESOURCE scopes can be one of
+        # DeveloperRead | DeveloperWrite | ResourceOwner | DeveloperManage
+        # Or, for CLUSTER scope onle, one of:
+        # SystemAdmin | ClusterAdmin | UserAdmin | SecurityAdmin | AuditAdmin | Operator
+        role: DeveloperRead
+        # Resource is only needed when scope=RESOURCE. It should be empty otherwise
+        # So examples for resource type are:
+        # Topic | Subject | Group | Connector | TransactionalId
+        resources:
+          - name: trololo
+            resource_type: Topic
+            # Pattern type can be one of:
+            # LITERAL | PREFIXED
+            pattern_type: LITERAL
+          - name: Skata
+            resource_type: Topic
+            pattern_type: PREFIXED
+      - context: SR
+        scope: CLUSTER
+        role: SecurityAdmin 
+        # Pattern type 
+        pattern_type: LITERAL
 connectors:
   - name: skata1
     config:

--- a/testdata/files/data/sample.yaml
+++ b/testdata/files/data/sample.yaml
@@ -77,3 +77,31 @@ clients:
         # if not specified, roles is [DeveloperRead]
         roles: ["ResourceOwner"]
         isLiteral: true
+    rolebindings:
+      # context can be one of:
+      # KAFKA | SR | KSQLDB | CONNECT 
+      - context: KAFKA 
+        # Scope can be one of CLUSTER | RESOURCE
+        scope: RESOURCE
+        # Role , for CLUSTER or RESOURCE scopes can be one of
+        # DeveloperRead | DeveloperWrite | ResourceOwner | DeveloperManage
+        # Or, for CLUSTER scope onle, one of:
+        # SystemAdmin | ClusterAdmin | UserAdmin | SecurityAdmin | AuditAdmin | Operator
+        role: DeveloperRead
+        # Resource is only needed when scope=RESOURCE. It should be empty otherwise
+        # So examples for resource type are:
+        # Topic | Subject | Group | Connector | TransactionalId
+        resources:
+          - name: trololo
+            resource_type: Topic
+            # Pattern type can be one of:
+            # LITERAL | PREFIXED
+            pattern_type: LITERAL
+          - name: Skata
+            resource_type: Topic
+            pattern_type: PREFIXED
+      - context: SR
+        scope: CLUSTER
+        role: SecurityAdmin 
+        # Pattern type 
+        pattern_type: LITERAL


### PR DESCRIPTION
Add support for custom Confluent RBAC rolebinding definitions.
Current versions of  `gafkalo` support some predefined role grouping like `consumer_for` , `producer_for` etc. 

Sometimes it is useful to create specific rolebindings that are not supported by the existing grouping.
This PR allows for a syntax similar to what the Confluent MDS API expects and the user can define their rolebindings as they want.

Example use case is granting cluster level permissins (Confluent applications require them).