### PR TITLE
consumer instantiation now creates http client with TLS transport as …

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -5,11 +5,12 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type ClientTopicRole struct {
@@ -180,6 +181,7 @@ func (admin *MDSAdmin) doRest(method string, url string, payload io.Reader) ([]b
 	resp, err := hClient.Do(req)
 	if err != nil {
 		log.Println(err)
+		return nil, err
 	}
 	respBody, err := ioutil.ReadAll(resp.Body)
 

--- a/topics.go
+++ b/topics.go
@@ -5,10 +5,11 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/Shopify/sarama"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"math/rand"
+
+	"github.com/Shopify/sarama"
+	log "github.com/sirupsen/logrus"
 )
 
 type Topic struct {
@@ -51,16 +52,19 @@ func createTlsConfig(CAPath string, SkipVerify bool) *tls.Config {
 	if rootCAs == nil {
 		rootCAs = x509.NewCertPool()
 	}
-	pem, err := ioutil.ReadFile(CAPath)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if ok := rootCAs.AppendCertsFromPEM(pem); !ok {
-		log.Fatalf("Could not append cert %s to CertPool\n", CAPath)
+	if CAPath != "" {
+		pem, err := ioutil.ReadFile(CAPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if ok := rootCAs.AppendCertsFromPEM(pem); !ok {
+			log.Fatalf("Could not append cert %s to CertPool\n", CAPath)
+		}
+		log.Tracef("Created TLS Config from PEM %s (InsecureSkipVerify=%v)", pem, SkipVerify)
 	}
 	config.RootCAs = rootCAs
 	config.InsecureSkipVerify = SkipVerify
-	log.Tracef("Created TLS Config from PEM %s (InsecureSkipVerify=%v)", pem, SkipVerify)
+	log.Tracef("Setting InsecureSkipVerify=%v", SkipVerify)
 	return config
 
 }


### PR DESCRIPTION
Consumer instances would not respect the caPath and skipverify settings for the schema registry.
This PR fixes bug #30 